### PR TITLE
Mention Bacon.awaiting in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,8 +152,6 @@ For example:
     var requestRunning = searchParams.awaiting(ajaxRequest)
     requestRunning.assign($('#ajaxSpinner'), 'toggle')
 
-`stream.awaiting(stream.ajax())`.
-
 ### stream.ajax(fn)
 
 Performs an AJAX request on each event of your stream, collating results in the result stream.


### PR DESCRIPTION
I spent a considerable time trying to find out how to catch requests aborted by Bacon.$.ajax, not knowing about `Bacon.awaiting`. Maybe someone will save time if this is mentioned in the docs :)
